### PR TITLE
Update to latest WebVR API

### DIFF
--- a/apibasics.js
+++ b/apibasics.js
@@ -1,5 +1,5 @@
 myVRApp.prototype.queryVRDevices = function() {
- 
+
        // Polyfill - hide FF/Webkit differences
        var getVRDevices = navigator.mozGetVRDevices /* FF */ ||
                            navigator.getVRDevices; /* webkit */
@@ -12,13 +12,31 @@ myVRApp.prototype.queryVRDevices = function() {
        var self = this;
        getVRDevices().then( gotVRDevices );
        function gotVRDevices( devices ) {
-            // Look for HMDVRDevice (display) first  
+            // Look for HMDVRDevice (display) first
             var vrHMD;
             var error;
             for ( var i = 0; i < devices.length; ++i ) {
                 if ( devices[i] instanceof HMDVRDevice ) {
                     vrHMD = devices[i];
                     self._vrHMD = vrHMD;
+                    if ( vrHMD.getEyeParameters ) {
+                      self.left = vrHMD.getEyeParameters( "left" );
+                      self.right = vrHMD.getEyeParameters( "right" );
+                    }
+                    else {
+                      self.left = {
+                        renderRect: vrHMD.getRecommendedEyeRenderRect( "left" ),
+                        eyeTranslation: vrHMD.getEyeTranslation( "left" ),
+                        recommendedFieldOfView: vrHMD.getRecommendedEyeFieldOfView(
+                            "left" )
+                      };
+                      self.right = {
+                        renderRect: vrHMD.getRecommendedEyeRenderRect( "right" ),
+                        eyeTranslation: vrHMD.getEyeTranslation( "right" ),
+                        recommendedFieldOfView: vrHMD.getRecommendedEyeFieldOfView(
+                            "right" )
+                      };
+                    }
                     self.leftEyeTranslation = vrHMD.getEyeTranslation( "left" );
                     self.rightEyeTranslation = vrHMD.getEyeTranslation( "right" );
                     self.leftEyeFOV = vrHMD.getRecommendedEyeFieldOfView( "left" );
@@ -42,10 +60,10 @@ myVRApp.prototype.queryVRDevices = function() {
     }
 
   myVRApp.prototype.goFullScreen = function() {
-    
+
     var vrHMD = this._vrHMD;
 
-    // this._canvas is an HTML5 canvas element 
+    // this._canvas is an HTML5 canvas element
     var canvas = this._canvas;
 
     // Polyfill - hide FF/Webkit differences

--- a/examples/cube-cardboard.html
+++ b/examples/cube-cardboard.html
@@ -32,10 +32,10 @@
 <script type="text/javascript">
 
 	var container = null,
-	renderer = null, 
+	renderer = null,
 	effect = null,
 	controls = null,
-	scene = null, 
+	scene = null,
 	camera = null,
 	cube = null;
 
@@ -45,7 +45,7 @@
 
 				// Set up Three.js
 				initThreeJS();
-				
+
 				// Set up VR rendering
 				initVREffect();
 
@@ -59,11 +59,11 @@
 		        run();
 			}
 	);
-	
+
     var duration = 10000; // ms
     var currentTime = Date.now();
 	function animate() {
-		
+
         var now = Date.now();
         var deltat = now - currentTime;
         currentTime = now;
@@ -74,7 +74,7 @@
 
 	function run() {
         requestAnimationFrame(function() { run(); });
-        
+
 			// Render the scene
 			effect.render( scene, camera );
 
@@ -83,9 +83,9 @@
 
 			// Spin the cube for next frame
 			animate();
-				
+
     }
-    
+
     function initThreeJS() {
 
 		container = document.getElementById("container");
@@ -97,10 +97,36 @@
 	    renderer.setSize(window.innerWidth, window.innerHeight);
 	    container.appendChild(renderer.domElement);
 
-		window.addEventListener( 'resize', function(event) { 
-			renderer.setSize(window.innerWidth, window.innerHeight);
-		}, false );
+		window.addEventListener( 'resize', refreshSize, false );
 
+    }
+
+    function refreshSize ( ) {
+        var fullWidth = document.body.clientWidth,
+            fullHeight = document.body.clientHeight,
+            canvasWidth,
+            canvasHeight,
+            aspectWidth;
+        if ( effect && effect.isFullScreen ) {
+            canvasWidth = effect.left.renderRect.width +
+                effect.right.renderRect.width;
+            canvasHeight = Math.max( effect.left.renderRect.height,
+                effect.right.renderRect.height );
+            aspectWidth = canvasWidth / 2;
+        }
+        else{
+            var ratio = window.devicePixelRatio || 1;
+            canvasWidth = fullWidth * ratio;
+            canvasHeight = fullHeight * ratio;
+            aspectWidth = canvasWidth;
+        }
+        renderer.domElement.style.width = fullWidth + "px";
+        renderer.domElement.style.height = fullHeight + "px";
+        renderer.domElement.width = canvasWidth;
+        renderer.domElement.height = canvasHeight;
+        renderer.setViewport( 0, 0, canvasWidth, canvasHeight );
+        camera.aspect = aspectWidth / canvasHeight;
+        camera.updateProjectionMatrix( );
     }
 
     function initVREffect() {
@@ -133,12 +159,12 @@
 		    // Add  a camera so we can view the scene
 	        camera = new THREE.PerspectiveCamera( 90, window.innerWidth / window.innerHeight, 1, 4000 );
 			scene.add(camera);
-			
+
 	        // Create a texture-mapped cube and add it to the scene
 	        // First, create the texture map
 	        var mapUrl = "../images/webvr-logo-512.jpeg";
 	        var map = THREE.ImageUtils.loadTexture(mapUrl);
-	        
+
 	        // Now, create a Basic material; pass in the map
 	        var material = new THREE.MeshBasicMaterial({ map: map });
 

--- a/examples/cube-oculus.html
+++ b/examples/cube-oculus.html
@@ -12,6 +12,7 @@
 				color: #FFF;
 				background-color: #555;
 				z-index:1;
+                cursor: pointer;
 			}
 
 			#container {
@@ -30,8 +31,6 @@
 	<div class="button">Start VR Mode</div>
     <div id="container"></div>
 
-</body>
-
 <script src="../libs/jquery-1.9.1/jquery-1.9.1.js"></script>
 <script src="../libs/three.js.r68/three.js"></script>
 <script src="../libs/three.js.r68/effects/VREffect.js"></script>
@@ -40,10 +39,10 @@
 <script type="text/javascript">
 
 	var container = null,
-	renderer = null, 
+	renderer = null,
 	effect = null,
 	controls = null,
-	scene = null, 
+	scene = null,
 	camera = null,
 	cube = null;
 
@@ -53,7 +52,7 @@
 
 				// Set up Three.js
 				initThreeJS();
-				
+
 				// Set up VR rendering
 				initVREffect();
 
@@ -63,15 +62,18 @@
 				// Set up VR camera controls
 				initVRControls();
 
+                // Set the viewport size and aspect ratio
+                refreshSize();
+
 		        // Run the run loop
 		        run();
 			}
 	);
-	
+
     var duration = 10000; // ms
     var currentTime = Date.now();
 	function animate() {
-		
+
         var now = Date.now();
         var deltat = now - currentTime;
         currentTime = now;
@@ -82,7 +84,7 @@
 
 	function run() {
         requestAnimationFrame(function() { run(); });
-        
+
 			// Render the scene
 			effect.render( scene, camera );
 
@@ -91,9 +93,9 @@
 
 			// Spin the cube for next frame
 			animate();
-				
+
     }
-    
+
     function initThreeJS() {
 
 		container = document.getElementById("container");
@@ -102,13 +104,38 @@
 	    renderer = new THREE.WebGLRenderer( { antialias: true } );
 
 	    // Set the viewport size
-	    renderer.setSize(window.innerWidth, window.innerHeight);
 	    container.appendChild(renderer.domElement);
 
-		window.addEventListener( 'resize', function(event) { 
-			renderer.setSize(window.innerWidth, window.innerHeight);
-		}, false );
+		window.addEventListener( 'resize', refreshSize, false );
 
+    }
+
+    function refreshSize ( ) {
+        var fullWidth = document.body.clientWidth,
+            fullHeight = document.body.clientHeight,
+            canvasWidth,
+            canvasHeight,
+            aspectWidth;
+        if ( effect && effect.isFullScreen ) {
+            canvasWidth = effect.left.renderRect.width +
+                effect.right.renderRect.width;
+            canvasHeight = Math.max( effect.left.renderRect.height,
+                effect.right.renderRect.height );
+            aspectWidth = canvasWidth / 2;
+        }
+        else{
+            var ratio = window.devicePixelRatio || 1;
+            canvasWidth = fullWidth * ratio;
+            canvasHeight = fullHeight * ratio;
+            aspectWidth = canvasWidth;
+        }
+        renderer.domElement.style.width = fullWidth + "px";
+        renderer.domElement.style.height = fullHeight + "px";
+        renderer.domElement.width = canvasWidth;
+        renderer.domElement.height = canvasHeight;
+        renderer.setViewport( 0, 0, canvasWidth, canvasHeight );
+        camera.aspect = aspectWidth / canvasHeight;
+        camera.updateProjectionMatrix( );
     }
 
     function initVREffect() {
@@ -116,10 +143,10 @@
 	    // Set up Oculus renderer
 	    effect = new THREE.VREffect(renderer, function(err) {
 	    	if (err) {
-	    		console.log("Error creating VREffect: ", err);			    		
+	    		console.log("Error creating VREffect: ", err);
 	    	}
 	    	else {
-	    		console.log("Created VREffect: ", effect);			    		
+	    		console.log("Created VREffect: ", effect);
 	    	}
 	    });
 
@@ -128,6 +155,17 @@
 		fullScreenButton.onclick = function() {
 			effect.setFullScreen(true);
 		};
+
+        window.addEventListener("keyup", function(evt){
+            if(!evt.shiftKey &&
+                !evt.altKey &&
+                !evt.ctrlKey &&
+                !evt.metaKey &&
+                evt.keyCode === 27 &&
+                effect.isFullScreen){
+                effect.setFullScreen(false);
+            }
+        });
     }
 
     function initScene() {
@@ -140,12 +178,12 @@
 		    // See VREffect.js h/t Michael Blix
 	        camera = new THREE.PerspectiveCamera( 90, window.innerWidth / window.innerHeight, 1, 4000 );
 			scene.add(camera);
-			
+
 	        // Create a texture-mapped cube and add it to the scene
 	        // First, create the texture map
 	        var mapUrl = "../images/webvr-logo-512.jpeg";
 	        var map = THREE.ImageUtils.loadTexture(mapUrl);
-	        
+
 	        // Now, create a Basic material; pass in the map
 	        var material = new THREE.MeshBasicMaterial({ map: map });
 
@@ -170,7 +208,7 @@
 		// Set up VR camera controls
 		controls = new THREE.VRControls(camera, function(err) {
 	    	if (err) {
-	    		console.log("Error creating VRControls: ", err);			    		
+	    		console.log("Error creating VRControls: ", err);
 	    	}
 	    	else {
 	    		console.log("Created VRControls: ", controls);
@@ -179,6 +217,8 @@
     }
 
 </script>
+
+</body>
 
 
 </html>

--- a/examples/cube-oculus.html
+++ b/examples/cube-oculus.html
@@ -47,53 +47,46 @@
 	cube = null;
 
 
-	$(document).ready(
-			function() {
+	$(document).ready(function() {
+        // Set up Three.js
+        initThreeJS();
 
-				// Set up Three.js
-				initThreeJS();
+        // Set up VR rendering
+        initVREffect();
 
-				// Set up VR rendering
-				initVREffect();
+        // Create the scene content
+        initScene();
 
-				// Create the scene content
-				initScene();
+        // Set up VR camera controls
+        initVRControls();
 
-				// Set up VR camera controls
-				initVRControls();
+        // Set the viewport size and aspect ratio
+        refreshSize();
 
-                // Set the viewport size and aspect ratio
-                refreshSize();
-
-		        // Run the run loop
-		        run();
-			}
-	);
+        // Run the run loop
+        requestAnimationFrame(run);
+    });
 
     var duration = 10000; // ms
-    var currentTime = Date.now();
-	function animate() {
-
-        var now = Date.now();
-        var deltat = now - currentTime;
-        currentTime = now;
+	function animate(deltat) {
         var fract = deltat / duration;
         var angle = Math.PI * 2 * fract;
 		cube.rotation.y += angle;
 	}
 
-	function run() {
-        requestAnimationFrame(function() { run(); });
+    var lastTime = 0;
+	function run(time) {
+        requestAnimationFrame(run);
+        var dt = time - lastTime;
+        lastTime = time;
+        // Render the scene
+        effect.render( scene, camera );
 
-			// Render the scene
-			effect.render( scene, camera );
+        // Update the VR camera controls
+        controls.update();
 
-			// Update the VR camera controls
-			controls.update();
-
-			// Spin the cube for next frame
-			animate();
-
+        // Spin the cube for next frame
+        animate(dt);
     }
 
     function initThreeJS() {

--- a/libs/three.js.r68/effects/VREffect.js
+++ b/libs/three.js.r68/effects/VREffect.js
@@ -145,25 +145,14 @@ THREE.VREffect = function ( renderer, done ) {
 			return;
 		}
 		// If state doesn't change we do nothing
-		if ( enable === this._fullScreen ) {
+		if ( enable === this.isFullScreen ) {
 			return;
 		}
-		this._fullScreen = !!enable;
+		this.isFullScreen = !!enable;
 
-		// VR Mode disabled
-		if ( !enable ) {
-			// Restores canvas original size
-			renderer.setSize( canvasOriginalSize.width, canvasOriginalSize.height );
-			return;
-		}
-		// VR Mode enabled
-		this._canvasOriginalSize = {
-			width: renderer.domElement.width,
-			height: renderer.domElement.height
-		};
-		// Hardcoded Rift display size
-		renderer.setSize( 1280, 800, false );
-		this.startFullscreen();
+		if ( enable ) {
+          this.startFullscreen();
+        }
 	};
 
 	this.startFullscreen = function() {

--- a/libs/three.js.r68/effects/VREffect.js
+++ b/libs/three.js.r68/effects/VREffect.js
@@ -48,10 +48,24 @@ THREE.VREffect = function ( renderer, done ) {
 				if ( devices[i] instanceof HMDVRDevice ) {
 					vrHMD = devices[i];
 					self._vrHMD = vrHMD;
-					self.leftEyeTranslation = vrHMD.getEyeTranslation( "left" );
-					self.rightEyeTranslation = vrHMD.getEyeTranslation( "right" );
-					self.leftEyeFOV = vrHMD.getRecommendedEyeFieldOfView( "left" );
-					self.rightEyeFOV = vrHMD.getRecommendedEyeFieldOfView( "right" );
+                    if ( vrHMD.getEyeParameters ) {
+                      self.left = vrHMD.getEyeParameters( "left" );
+                      self.right = vrHMD.getEyeParameters( "right" );
+                    }
+                    else {
+                      self.left = {
+                        renderRect: vrHMD.getRecommendedEyeRenderRect( "left" ),
+                        eyeTranslation: vrHMD.getEyeTranslation( "left" ),
+                        recommendedFieldOfView: vrHMD.getRecommendedEyeFieldOfView(
+                            "left" )
+                      };
+                      self.right = {
+                        renderRect: vrHMD.getRecommendedEyeRenderRect( "right" ),
+                        eyeTranslation: vrHMD.getEyeTranslation( "right" ),
+                        recommendedFieldOfView: vrHMD.getRecommendedEyeFieldOfView(
+                            "right" )
+                      };
+                    }
 					break; // We keep the first we encounter
 				}
 			}
@@ -80,8 +94,10 @@ THREE.VREffect = function ( renderer, done ) {
 
 	this.renderStereo = function( scene, camera, renderTarget, forceClear ) {
 
-		var leftEyeTranslation = this.leftEyeTranslation;
-		var rightEyeTranslation = this.rightEyeTranslation;
+		var leftEyeTranslation = this.left.eyeTranslation;
+		var rightEyeTranslation = this.right.eyeTranslation;
+        var leftFOV = this.left.recommendedFieldOfView;
+        var rightFOV = this.right.recommendedFieldOfView;
 		var renderer = this._renderer;
 		var rendererWidth = renderer.domElement.width / renderer.devicePixelRatio;
 		var rendererHeight = renderer.domElement.height / renderer.devicePixelRatio;
@@ -94,8 +110,8 @@ THREE.VREffect = function ( renderer, done ) {
 			camera.updateMatrixWorld();
 		}
 
-		cameraLeft.projectionMatrix = this.FovToProjection( this.leftEyeFOV, true, camera.near, camera.far );
-		cameraRight.projectionMatrix = this.FovToProjection( this.rightEyeFOV, true, camera.near, camera.far );
+		cameraLeft.projectionMatrix = this.FovToProjection( leftFOV, true, camera.near, camera.far );
+		cameraRight.projectionMatrix = this.FovToProjection( rightFOV, true, camera.near, camera.far );
 
 		camera.matrixWorld.decompose( cameraLeft.position, cameraLeft.quaternion, cameraLeft.scale );
 		camera.matrixWorld.decompose( cameraRight.position, cameraRight.quaternion, cameraRight.scale );


### PR DESCRIPTION
This should be backwards compatible with the original WebVR API from 2014. Though I don't have a copy around to test, this is the same code I used when I upgraded months ago and it worked fine back then. It's a simple enough change to get right.

The underlying structures are all the same, you just get them in a slightly different way. By replicating the new structure with the old API calls, then upgrade the rest of the code to use the new API's structure organization, it makes supporting both APIs quite simple.

I've also included code for correctly managing the canvas size for a variety of different display types, and a small change to the animation code to use the deltaTime parameter that the requestAnimationFrame call provides to its callback. It's not a noticeable difference, but it should be more "future proof" this way.
- Sean T. McBeth sean.mcbeth@gmail.com
